### PR TITLE
Verificação de disponibilidade de ingressos e ajustes no cadastro de peças

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Informações do Projeto -->
     <groupId>ingressart</groupId>
     <artifactId>ingressart-teatro</artifactId>
     <version>1.0.0</version>
@@ -14,15 +13,28 @@
     <description>Sistema de gerenciamento para teatros</description>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>1.8</java.version>
+        <spring-boot.version>3.1.0</spring-boot.version>
         <postgresql.version>42.6.0</postgresql.version>
         <hikaricp.version>5.0.1</hikaricp.version>
         <junit.version>5.9.2</junit.version>
     </properties>
 
     <dependencies>
+        <!-- Spring Boot Starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Starter JDBC -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+
         <!-- PostgreSQL -->
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -30,7 +42,7 @@
             <version>${postgresql.version}</version>
         </dependency>
 
-        <!-- Pool de Conexões -->
+        <!-- HikariCP -->
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
@@ -72,14 +84,25 @@
 
     <build>
         <plugins>
-            <!-- Compilador Java -->
+            <!-- Compilador -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
             </plugin>
 
-            <!-- Criar JAR executável -->
+            <!-- Spring Boot plugin (para spring-boot:run) -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+
+            <!-- JAR executável -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -101,38 +124,12 @@
                 </executions>
             </plugin>
 
-            <!-- Executar testes -->
+            <!-- Testes -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M7</version>
             </plugin>
-
-            <!-- Formatação de código -->
-            <plugin>
-                <groupId>net.revelc.code</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.20.0</version>
-                <configuration>
-                    <configFile>${basedir}/formatter.xml</configFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
-
-    <!-- Configuração de Relatórios -->
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.4.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.0.0-M7</version>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>

--- a/src/main/java/ingressart/teatro/controller/MenuCliente.java
+++ b/src/main/java/ingressart/teatro/controller/MenuCliente.java
@@ -16,8 +16,8 @@ import ingressart.teatro.model.Ingresso;
 import ingressart.teatro.model.Peca;
 import ingressart.teatro.model.Pessoa;
 import ingressart.teatro.model.Review;
+import ingressart.teatro.model.Sessao;
 // import ingressart.teatro.model.Evento;
-// import ingressart.teatro.model.Sessao;
 // import ingressart.teatro.model.Venda;
 
 
@@ -172,6 +172,26 @@ private void listarMeusEventos(Pessoa cliente) {
 
     private void realizarCompra(Pessoa cliente, Peca peca) {
         try {
+            Sessao sessao = sessaoDAO.findByEventoId(peca.getId_peca());
+            if (sessao == null){
+                System.out.println("Sessão não encontrada");
+                return;
+            }
+            int quantidade = 1;
+            if (!sessaoDAO.verificarDisponibilidade(sessao.getId_sessao(), quantidade)){
+                System.out.println("Essa peça está com lotação máxima.");
+                return;
+            }
+            System.out.printf("Ingressos disponíveis: %d%n", sessao.getNum_ingressos_disp());
+            System.out.print("Quantos ingressos deseja comprar? ");
+            quantidade = Integer.parseInt(scanner.nextLine());
+
+            if (!sessaoDAO.verificarDisponibilidade(sessao.getId_sessao(), quantidade) || quantidade<=0){
+                System.out.println("Quantidade indisponível.");
+                return;
+            }
+
+            for(int i=0;i<quantidade;i++){
             Ingresso ingresso = new Ingresso();
             ingresso.setId_cliente(cliente.getId_pessoa());
             ingresso.setId_peca(peca.getId_peca());
@@ -180,9 +200,13 @@ private void listarMeusEventos(Pessoa cliente) {
             ingresso.setStatus(true);
             
             ingressoDAO.insert(ingresso);
-            System.out.println("Ingresso comprado com sucesso!");
+            }
+            sessaoDAO.reduzirIngressosDisponiveis(sessao.getId_sessao(), quantidade);
+            System.out.println("Ingresso(s) comprado(s) com sucesso!");
         } catch (SQLException ex) {
             System.err.println("Erro ao comprar ingresso: " + ex.getMessage());
+        } catch(NumberFormatException e){
+            System.err.println("Número inválido.");
         }
     }
 

--- a/src/main/java/ingressart/teatro/controller/MenuCliente.java
+++ b/src/main/java/ingressart/teatro/controller/MenuCliente.java
@@ -1,12 +1,17 @@
 // src/main/java/grupo3/java_backend/controller/MenuCliente.java
 package ingressart.teatro.controller;
 
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Scanner;
+
 import ingressart.teatro.dao.EventoDAO;
 import ingressart.teatro.dao.IngressoDAO;
 import ingressart.teatro.dao.PecaDAO;
+import ingressart.teatro.dao.PessoaDAO;
+import ingressart.teatro.dao.ReviewDAO;
 import ingressart.teatro.dao.SessaoDAO;
 import ingressart.teatro.dao.VendaDAO;
-import ingressart.teatro.dao.ReviewDAO;
 import ingressart.teatro.model.Ingresso;
 import ingressart.teatro.model.Peca;
 import ingressart.teatro.model.Pessoa;
@@ -21,6 +26,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Scanner;
 
+
 public class MenuCliente {
     private Scanner scanner = new Scanner(System.in);
     private EventoDAO eventoDAO = new EventoDAO();
@@ -29,7 +35,7 @@ public class MenuCliente {
     private VendaDAO vendaDAO = new VendaDAO();
     private PecaDAO pecaDAO = new PecaDAO();
     private ReviewDAO reviewDAO = new ReviewDAO();
-
+    private PessoaDAO pessoaDAO = new PessoaDAO(); 
     public void iniciar(Pessoa cliente) {
         while (true) {
             System.out.println("--- Menu Cliente ---");
@@ -136,7 +142,6 @@ public class MenuCliente {
 }
 }
 
-
     private void listarMeusEventos(Pessoa cliente) {
         System.out.println("Funcionalidade 'Meus Eventos' ainda não implementada.\n");
     }
@@ -219,23 +224,45 @@ public class MenuCliente {
     private void visualizarAvaliacoes() {
         try {
             System.out.println("\n--- Avaliações das Peças ---");
+            
             List<Peca> pecas = pecaDAO.findAll();
             
+
+            if (pecas.isEmpty()){
+                System.out.println("Nenhuma peça encontrada.");
+            }
             for (Peca peca : pecas) {
+        
                 List<Review> reviews = reviewDAO.findByPecaId(peca.getId_peca());
-                if (!reviews.isEmpty()) {
+                if(reviews.isEmpty()){
                     System.out.printf("\nPeça: %s\n", peca.getNome());
+                    System.out.println("Nenhuma avaliação encontrada.");
+                    continue;
+                }
+                if (!reviews.isEmpty()) {
+                
                     double mediaRating = reviews.stream()
                         .mapToInt(Review::getRating)
                         .average()
-                        .orElse(0.0);
-                    System.out.printf("Média de avaliações: %.1f estrelas\n", mediaRating);
-                    System.out.println("Avaliações:");
+                        .orElse(0.0);  
+
+                    long quantidadeAvaliacoes = reviews.size();  
                     
+                    System.out.printf("\nPeça: %s\n", peca.getNome());
+                    System.out.printf("Média de avaliações: %.1f estrelas (%d avaliações)\n", mediaRating, quantidadeAvaliacoes);
+                    System.out.println("Avaliações:");
+
+            
                     for (Review review : reviews) {
-                        System.out.printf("- %d estrelas: %s\n", 
+                        // Recupera o cliente que fez a avaliação
+                        Pessoa clienteAvaliado = pessoaDAO.findById(review.getId_cliente());
+                        String nomeCliente = clienteAvaliado != null ? clienteAvaliado.getNome() : "Desconhecido";
+
+                  
+                        System.out.printf("- %d estrelas: %s (Comentário: %s)\n", 
                             review.getRating(), 
-                            review.getComentario() != null ? review.getComentario() : "(sem comentário)");
+                            nomeCliente, 
+                            review.getComentario() != null ? review.getComentario() : "(Sem comentário)");
                     }
                 }
             }

--- a/src/main/java/ingressart/teatro/controller/MenuCliente.java
+++ b/src/main/java/ingressart/teatro/controller/MenuCliente.java
@@ -126,9 +126,33 @@ public class MenuCliente {
 }
 
 
-    private void listarMeusEventos(Pessoa cliente) {
-        System.out.println("Funcionalidade 'Meus Eventos' ainda não implementada.\n");
+private void listarMeusEventos(Pessoa cliente) {
+    try {
+        List<Ingresso> ingressos = ingressoDAO.findByClienteId(cliente.getId_pessoa());
+
+        if (ingressos.isEmpty()) {
+            System.out.println("Você ainda não comprou ingressos.\n");
+            return;
+        }
+
+        System.out.println("--- Meus Ingressos ---");
+        for (Ingresso ingresso : ingressos) {
+            Peca peca = pecaDAO.findById(ingresso.getId_peca());
+            System.out.printf("Peça: %s (%s %s)\n", 
+                peca.getNome(), 
+                peca.getData(), 
+                peca.getHora());
+            System.out.printf("Tipo: %s | Preço: R$%.2f | Status: %s\n\n", 
+                ingresso.getTipo_ingresso(), 
+                ingresso.getPreco_ingresso(), 
+                ingresso.isStatus() ? "Ativo" : "Inativo");
+        }
+
+    } catch (SQLException ex) {
+        System.err.println("Erro ao listar seus eventos: " + ex.getMessage());
     }
+}
+
 
     private void realizarCompra(Pessoa cliente, Peca peca) {
         try {

--- a/src/main/java/ingressart/teatro/controller/MenuTeatro.java
+++ b/src/main/java/ingressart/teatro/controller/MenuTeatro.java
@@ -1,5 +1,6 @@
 package ingressart.teatro.controller;
 
+import ingressart.teatro.util.ValidadorDePeca;
 import ingressart.teatro.dao.*;
 import ingressart.teatro.model.Evento;
 import ingressart.teatro.model.Sessao;
@@ -76,11 +77,13 @@ public class MenuTeatro {
                 System.out.println("Nenhuma sala cadastrada. Cadastre uma sala primeiro.\n");
                 return;
             }
+    
             System.out.println("\nSalas disponíveis:");
             for (Sala s : salas) {
                 System.out.printf("  %d - %s (Capacidade: %d)%n",
                     s.getId_sala(), s.getTipo(), s.getCapacidade());
             }
+    
             System.out.print("\nID da sala para esta peça: ");
             int idSala = Integer.parseInt(scanner.nextLine());
             Sala sala = salaDAO.findById(idSala);
@@ -107,15 +110,22 @@ public class MenuTeatro {
             peca.setData(data);
             peca.setHora(horaPeca);
             peca.setValor_ingresso(valorIngresso);
-            pecaDAO.insert(peca);
     
+            // validação antes do insert no banco de dados
+            String erro = ValidadorDePeca.validar(peca);
+            if (erro != null) {
+                System.out.println("Erro ao cadastrar peça: " + erro);
+                return;
+            }
+    
+            pecaDAO.insert(peca);
             System.out.println("\nPeça cadastrada com sucesso!");
             System.out.printf("Peça ID: %d\n", peca.getId_peca());
     
         } catch (Exception ex) {
             System.err.println("Erro ao cadastrar peça: " + ex.getMessage());
         }
-    }
+    }    
 
     private void listarPecas() {
         try {
@@ -189,6 +199,13 @@ public class MenuTeatro {
                     System.out.println("Opção inválida.");
                     return;
             }
+
+            String erro = ValidadorDePeca.validar(peca);
+                if (erro != null) {
+                    System.out.println("Erro ao atualizar peça: " + erro);
+                    return;
+            }
+
             pecaDAO.update(peca);
             System.out.println("\nPeça atualizada com sucesso!");
         } catch (Exception ex) {

--- a/src/main/java/ingressart/teatro/controller/MenuTeatro.java
+++ b/src/main/java/ingressart/teatro/controller/MenuTeatro.java
@@ -306,8 +306,8 @@ public class MenuTeatro {
             System.out.println("\n--- Cadastro de Nova Sessão ---");
             System.out.print("Digite o ID da peça (evento) para criar a sessão: ");
             int idEvento = Integer.parseInt(scanner.nextLine());
-            Evento evento = eventoDAO.findById(idEvento);
-            if (evento == null) {
+            Peca peca = pecaDAO.findById(idEvento);
+            if (peca == null) {
                 System.out.println("Evento não encontrado!");
                 return;
             }

--- a/src/main/java/ingressart/teatro/dao/ConnectionFactory.java
+++ b/src/main/java/ingressart/teatro/dao/ConnectionFactory.java
@@ -5,19 +5,25 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public class ConnectionFactory {
-    private static final String URL = "jdbc:postgresql://localhost:5432/ingressart";
-    private static final String USER = "postgres";
-    private static final String PASS = "postgres";
+    
+    private static final String URL = "jdbc:postgresql://localhost:5432/ingressart"; 
+    private static final String USER = "postgres";  //eu usuário do banco
+    private static final String PASS = "postgres";  // sua senha do banco
 
+    // Bloco estático que carrega o driver do PostgreSQL
     static {
         try {
+            // Carregando o driver PostgreSQL
             Class.forName("org.postgresql.Driver");
         } catch (ClassNotFoundException e) {
+            // Se o driver não for encontrado, uma exceção é lançada
             throw new RuntimeException("PostgreSQL JDBC driver not found", e);
         }
     }
 
+    // Método para obter uma conexão com o banco de dados
     public static Connection getConnection() throws SQLException {
+        // Retorna a conexão usando a URL, usuário e senha configurados
         return DriverManager.getConnection(URL, USER, PASS);
     }
 }

--- a/src/main/java/ingressart/teatro/dao/IngressoDAO.java
+++ b/src/main/java/ingressart/teatro/dao/IngressoDAO.java
@@ -89,5 +89,28 @@ public class IngressoDAO {
             stmt.executeUpdate();
         }
     }
+
+    public List<Ingresso> findByClienteId(int idCliente) throws SQLException {
+        String sql = "SELECT * FROM ingresso WHERE id_cliente = ?";
+        List<Ingresso> list = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, idCliente);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    Ingresso i = new Ingresso();
+                    i.setId_ingresso(rs.getInt("id_ingresso"));
+                    i.setId_assento(rs.getInt("id_assento"));
+                    i.setTipo_ingresso(rs.getString("tipo_ingresso"));
+                    i.setPreco_ingresso(rs.getDouble("preco_ingresso"));
+                    i.setStatus(rs.getBoolean("status"));
+                    i.setId_cliente(rs.getInt("id_cliente"));
+                    i.setId_peca(rs.getInt("id_peca"));
+                    list.add(i);
+                }
+            }
+        }
+        return list;
+    }
 }
 

--- a/src/main/java/ingressart/teatro/dao/IngressoDAO.java
+++ b/src/main/java/ingressart/teatro/dao/IngressoDAO.java
@@ -95,28 +95,28 @@ public class IngressoDAO {
             stmt.executeUpdate();
         }
     }
-
-    public List<Ingresso> findByClienteId(int idCliente) throws SQLException {
-        String sql = "SELECT * FROM ingresso WHERE id_cliente = ?";
-        List<Ingresso> list = new ArrayList<>();
-        try (Connection conn = ConnectionFactory.getConnection();
-             PreparedStatement stmt = conn.prepareStatement(sql)) {
-            stmt.setInt(1, idCliente);
-            try (ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    Ingresso i = new Ingresso();
-                    i.setId_ingresso(rs.getInt("id_ingresso"));
-                    i.setId_assento(rs.getInt("id_assento"));
-                    i.setTipo_ingresso(rs.getString("tipo_ingresso"));
-                    i.setPreco_ingresso(rs.getDouble("preco_ingresso"));
-                    i.setStatus(rs.getBoolean("status"));
-                    i.setId_cliente(rs.getInt("id_cliente"));
-                    i.setId_peca(rs.getInt("id_peca"));
-                    list.add(i);
-                }
-            }
-        }
-        return list;
-    }
 }
+//     public List<Ingresso> findByClienteId(int idCliente) throws SQLException {
+//         String sql = "SELECT * FROM ingresso WHERE id_cliente = ?";
+//         List<Ingresso> list = new ArrayList<>();
+//         try (Connection conn = ConnectionFactory.getConnection();
+//              PreparedStatement stmt = conn.prepareStatement(sql)) {
+//             stmt.setInt(1, idCliente);
+//             try (ResultSet rs = stmt.executeQuery()) {
+//                 while (rs.next()) {
+//                     Ingresso i = new Ingresso();
+//                     i.setId_ingresso(rs.getInt("id_ingresso"));
+//                     i.setId_assento(rs.getInt("id_assento"));
+//                     i.setTipo_ingresso(rs.getString("tipo_ingresso"));
+//                     i.setPreco_ingresso(rs.getDouble("preco_ingresso"));
+//                     i.setStatus(rs.getBoolean("status"));
+//                     i.setId_cliente(rs.getInt("id_cliente"));
+//                     i.setId_peca(rs.getInt("id_peca"));
+//                     list.add(i);
+//                 }
+//             }
+//         }
+//         return list;
+//     }
+// }
 

--- a/src/main/java/ingressart/teatro/dao/IngressoDAO.java
+++ b/src/main/java/ingressart/teatro/dao/IngressoDAO.java
@@ -4,12 +4,14 @@ import ingressart.teatro.model.Ingresso;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import ingressart.teatro.util.Conexao;
+
 
 public class IngressoDAO {
     public void insert(Ingresso i) throws SQLException {
         String sql = "INSERT INTO ingresso (id_assento, tipo_ingresso, preco_ingresso, status, id_cliente, id_peca) VALUES (?, ?, ?, ?, ?, ?)";
         try (Connection conn = ConnectionFactory.getConnection();
-             PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             stmt.setInt(1, i.getId_assento());
             stmt.setString(2, i.getTipo_ingresso());
             stmt.setDouble(3, i.getPreco_ingresso());
@@ -45,26 +47,30 @@ public class IngressoDAO {
         return null;
     }
 
-    public List<Ingresso> findAll() throws SQLException {
-        String sql = "SELECT * FROM ingresso";
-        List<Ingresso> list = new ArrayList<>();
-        try (Connection conn = ConnectionFactory.getConnection();
-             Statement stmt = conn.createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
+    public List<Ingresso> findByClienteId(int clienteId) throws SQLException {
+        List<Ingresso> ingressos = new ArrayList<>();
+        String sql = "SELECT * FROM ingresso WHERE id_cliente = ?";
+        
+        try (Connection conn = Conexao.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, clienteId);
+            ResultSet rs = stmt.executeQuery();
+    
             while (rs.next()) {
-                Ingresso i = new Ingresso();
-                i.setId_ingresso(rs.getInt("id_ingresso"));
-                i.setId_assento(rs.getInt("id_assento"));
-                i.setTipo_ingresso(rs.getString("tipo_ingresso"));
-                i.setPreco_ingresso(rs.getDouble("preco_ingresso"));
-                i.setStatus(rs.getBoolean("status"));
-                i.setId_cliente(rs.getInt("id_cliente"));
-                i.setId_peca(rs.getInt("id_peca"));
-                list.add(i);
+                Ingresso ingresso = new Ingresso();
+                ingresso.setId_ingresso(rs.getInt("id_ingresso"));
+                ingresso.setId_cliente(rs.getInt("id_cliente"));
+                ingresso.setId_peca(rs.getInt("id_peca"));
+                ingresso.setTipo_ingresso(rs.getString("tipo_ingresso"));
+                ingresso.setPreco_ingresso(rs.getDouble("preco_ingresso"));
+                ingresso.setStatus(rs.getBoolean("status"));
+                ingressos.add(ingresso);
             }
         }
-        return list;
+    
+        return ingressos;
     }
+    
 
     public void update(Ingresso i) throws SQLException {
         String sql = "UPDATE ingresso SET id_assento=?, tipo_ingresso=?, preco_ingresso=?, status=?, id_cliente=?, id_peca=? WHERE id_ingresso=?";

--- a/src/main/java/ingressart/teatro/dao/ReviewDAO.java
+++ b/src/main/java/ingressart/teatro/dao/ReviewDAO.java
@@ -1,9 +1,15 @@
 package ingressart.teatro.dao;
 
-import ingressart.teatro.model.Review;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+
+import ingressart.teatro.model.Review;
 
 public class ReviewDAO {
     public void insert(Review r) throws SQLException {
@@ -68,4 +74,5 @@ public class ReviewDAO {
         }
         return reviews;
     }
+
 }

--- a/src/main/java/ingressart/teatro/dao/ReviewDAO.java
+++ b/src/main/java/ingressart/teatro/dao/ReviewDAO.java
@@ -1,0 +1,71 @@
+package ingressart.teatro.dao;
+
+import ingressart.teatro.model.Review;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReviewDAO {
+    public void insert(Review r) throws SQLException {
+        String sql = "INSERT INTO review (id_cliente, id_peca, rating, comentario, data_review) VALUES (?, ?, ?, ?, ?)";
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setInt(1, r.getId_cliente());
+            stmt.setInt(2, r.getId_peca());
+            stmt.setInt(3, r.getRating());
+            stmt.setString(4, r.getComentario());
+            stmt.setTimestamp(5, Timestamp.valueOf(r.getData_review()));
+            stmt.executeUpdate();
+            
+            try (ResultSet rs = stmt.getGeneratedKeys()) {
+                if (rs.next()) {
+                    r.setId_review(rs.getInt(1));
+                }
+            }
+        }
+    }
+
+    public List<Review> findByPecaId(int idPeca) throws SQLException {
+        String sql = "SELECT * FROM review WHERE id_peca = ? ORDER BY data_review DESC";
+        List<Review> reviews = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, idPeca);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    Review r = new Review();
+                    r.setId_review(rs.getInt("id_review"));
+                    r.setId_cliente(rs.getInt("id_cliente"));
+                    r.setId_peca(rs.getInt("id_peca"));
+                    r.setRating(rs.getInt("rating"));
+                    r.setComentario(rs.getString("comentario"));
+                    r.setData_review(rs.getTimestamp("data_review").toLocalDateTime());
+                    reviews.add(r);
+                }
+            }
+        }
+        return reviews;
+    }
+
+    public List<Review> findByClienteId(int idCliente) throws SQLException {
+        String sql = "SELECT * FROM review WHERE id_cliente = ? ORDER BY data_review DESC";
+        List<Review> reviews = new ArrayList<>();
+        try (Connection conn = ConnectionFactory.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, idCliente);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    Review r = new Review();
+                    r.setId_review(rs.getInt("id_review"));
+                    r.setId_cliente(rs.getInt("id_cliente"));
+                    r.setId_peca(rs.getInt("id_peca"));
+                    r.setRating(rs.getInt("rating"));
+                    r.setComentario(rs.getString("comentario"));
+                    r.setData_review(rs.getTimestamp("data_review").toLocalDateTime());
+                    reviews.add(r);
+                }
+            }
+        }
+        return reviews;
+    }
+}

--- a/src/main/java/ingressart/teatro/dao/SessaoDAO.java
+++ b/src/main/java/ingressart/teatro/dao/SessaoDAO.java
@@ -144,4 +144,21 @@ public class SessaoDAO {
         }
         return list;
     }
+
+
+    public boolean verificarDisponibilidade(int idSessao, int quantidadeSolicitada) throws SQLException {
+    Sessao sessao = findById(idSessao);
+    if (sessao == null) return false;
+
+    return sessao.getNum_ingressos_disp() >= quantidadeSolicitada;
+    }
+
+    public void reduzirIngressosDisponiveis(int idSessao, int quantidade) throws SQLException {
+    Sessao sessao = findById(idSessao);
+    if (sessao != null) {
+        int novoTotal = sessao.getNum_ingressos_disp() - quantidade;
+        sessao.setNum_ingressos_disp(novoTotal);
+        update(sessao);
+        }
+    }
 }

--- a/src/main/java/ingressart/teatro/database/update_schema.sql
+++ b/src/main/java/ingressart/teatro/database/update_schema.sql
@@ -64,4 +64,15 @@ CREATE TABLE venda (
     forma_pagamento VARCHAR(50),
     id_cliente INTEGER,
     FOREIGN KEY (id_cliente) REFERENCES pessoa(id_pessoa)
+);
+
+CREATE TABLE review (
+    id_review SERIAL PRIMARY KEY,
+    id_cliente INTEGER NOT NULL,
+    id_peca INTEGER NOT NULL,
+    rating INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    comentario TEXT,
+    data_review TIMESTAMP NOT NULL,
+    FOREIGN KEY (id_cliente) REFERENCES pessoa(id_pessoa),
+    FOREIGN KEY (id_peca) REFERENCES peca(id_peca)
 ); 

--- a/src/main/java/ingressart/teatro/model/Review.java
+++ b/src/main/java/ingressart/teatro/model/Review.java
@@ -1,0 +1,60 @@
+package ingressart.teatro.model;
+
+import java.time.LocalDateTime;
+
+public class Review {
+    private int id_review;
+    private int id_cliente;
+    private int id_peca;
+    private int rating;
+    private String comentario;
+    private LocalDateTime data_review;
+
+    public int getId_review() {
+        return id_review;
+    }
+
+    public void setId_review(int id_review) {
+        this.id_review = id_review;
+    }
+
+    public int getId_cliente() {
+        return id_cliente;
+    }
+
+    public void setId_cliente(int id_cliente) {
+        this.id_cliente = id_cliente;
+    }
+
+    public int getId_peca() {
+        return id_peca;
+    }
+
+    public void setId_peca(int id_peca) {
+        this.id_peca = id_peca;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+
+    public String getComentario() {
+        return comentario;
+    }
+
+    public void setComentario(String comentario) {
+        this.comentario = comentario;
+    }
+
+    public LocalDateTime getData_review() {
+        return data_review;
+    }
+
+    public void setData_review(LocalDateTime data_review) {
+        this.data_review = data_review;
+    }
+}

--- a/src/main/java/ingressart/teatro/util/Conexao.java
+++ b/src/main/java/ingressart/teatro/util/Conexao.java
@@ -1,0 +1,15 @@
+package ingressart.teatro.util;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class Conexao {
+    private static final String URL = "jdbc:postgresql://localhost:5432/ingressart";
+    private static final String USUARIO = "postgres";
+    private static final String SENHA = "postgres";
+
+    public static Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(URL, USUARIO, SENHA);
+    }
+}

--- a/src/main/java/ingressart/teatro/util/ValidadorDePeca.java
+++ b/src/main/java/ingressart/teatro/util/ValidadorDePeca.java
@@ -1,0 +1,22 @@
+package ingressart.teatro.util;
+
+import ingressart.teatro.model.Peca;
+import java.time.LocalDate;
+
+public class ValidadorDePeca {
+    public static String validar(Peca peca) {
+        if (peca.getNome() == null || peca.getNome().trim().isEmpty()) {
+            return "Nome é obrigatório";
+        }
+        if (peca.getDescricao() == null || peca.getDescricao().trim().isEmpty()) {
+            return "Descrição é obrigatória";
+        }
+        if (peca.getData() == null || peca.getData().isBefore(LocalDate.now())) {
+            return "Data inválida";
+        }
+        if (peca.getValor_ingresso() <= 0) {
+            return "Valor inválido";
+        }
+        return null; // válido
+    }
+}

--- a/src/test/java/ingressart/teatro/util/ValidadorDePecaTest.java
+++ b/src/test/java/ingressart/teatro/util/ValidadorDePecaTest.java
@@ -1,0 +1,69 @@
+package ingressart.teatro.util;
+
+import ingressart.teatro.model.Peca;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ValidadorDePecaTest {
+    
+    @Test
+    public void deveRetornarNullQuandoValida() {
+        Peca peca = new Peca();
+        peca.setNome("Hamlet");
+        peca.setDescricao("Tragédia clássica");
+        peca.setData(LocalDate.now().plusDays(1));
+        peca.setHora(LocalTime.of(20, 0));
+        peca.setValor_ingresso(50.0);
+    }
+
+    @Test
+    public void deveRetornarNomeVazio() {
+        Peca peca = new Peca();
+        peca.setNome("  ");
+        peca.setDescricao("Descrição qualquer");
+        peca.setData(LocalDate.now().plusDays(1));
+        peca.setHora(LocalTime.of(20,0));
+        peca.setValor_ingresso(50.0);
+
+        assertEquals("Nome é obrigatório", ValidadorDePeca.validar(peca));
+    }
+
+    @Test
+    public void deveDetectarDescricaoVazia() {
+        Peca peca = new Peca();
+        peca.setNome("Nome qualquer");
+        peca.setDescricao("  ");
+        peca.setData(LocalDate.now().plusDays(1));
+        peca.setHora(LocalTime.of(20, 0));
+        peca.setValor_ingresso(50.0);
+
+        assertEquals("Descrição é obrigatória", ValidadorDePeca.validar(peca));
+    }
+
+    @Test
+    public void deveDetectarDataNoPassado() {
+        Peca peca = new Peca();
+        peca.setNome("Nome qualquer");
+        peca.setDescricao("Descrição qualquer");
+        peca.setData(LocalDate.now().minusDays(1));
+        peca.setHora(LocalTime.of(20, 0));
+        peca.setValor_ingresso(50.0);
+        
+        assertEquals("Data inválida", ValidadorDePeca.validar(peca));
+    }
+
+    @Test
+    public void deveDetectarValorNegativo() {
+        Peca peca = new Peca();
+        peca.setNome("Nome qualquer");
+        peca.setDescricao("Descrição qualquer");
+        peca.setData(LocalDate.now().plusDays(1));
+        peca.setHora(LocalTime.of(20, 0));
+        peca.setValor_ingresso(-10.0);
+
+        assertEquals("Valor inválido", ValidadorDePeca.validar(peca));
+    }
+}


### PR DESCRIPTION
### Implementada verificação de disponibilidade de ingressos antes de finalizar a compra:

- O cliente só consegue comprar se houver ingressos disponíveis na sessão.

- Foi criado um método `verificarDisponibilidade()` no `SessaoDAO.java` para centralizar essa lógica.

- Após a compra, a quantidade de ingressos disponíveis na sessão é reduzida com `reduzirIngressosDisponiveis()`.

### Atualizado o método `realizarCompra()` no `MenuCliente.java`:

- Agora pergunta quantos ingressos o cliente quer comprar.

- Checa se essa quantidade está disponível.

- Só prossegue com a compra se a checagem for positiva.

- Atualiza a quantidade de ingressos disponíveis no banco de dados após a compra.

### Ajustado o cadastro de sessões para evitar conflito de ID entre peça e evento:

- O sistema agora usa `pecaDAO.java` em vez de `eventoDAO.java` durante o cadastro de sessões.

- Isso evita erros de consistência ao vincular sessões a peças que foram recém cadastradas, já que a Peca e Evento estavam com ID sobrepostos/conflitantes.

- Isso também garante que a verificação de disponibilidade funcione corretamente, pois depende do ID da peça estar corretamente associado à sessão.

